### PR TITLE
Use classes instead of namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ It's quite simple, really...
 ### Option\<T>
 
 ```typescript
-function nullableToOption<T>(value: T | null): Option<NonNullable<T>> {
-  if (value === null) {
+function nullableToOption<T>(value: T | null | undefined): Option<NonNullable<T>> {
+  if (value === null || value === undefined) {
     return Option.None();
   }
 
@@ -61,13 +61,13 @@ function nullableToOption<T>(value: T | null): Option<NonNullable<T>> {
 // Option<number>
 const maybeNumber = nullableToOption(5);
 
-if (Option.isSome(maybeNumber)) {
-  console.log(maybeNumber.value * 2);
+if (maybeNumber.isSome()) {
+  console.log(maybeNumber.unwrap() * 2);
 }
 ```
 
 ```typescript
-console.log(Option.map(Option.Some(5), (n) => n * 2));
+console.log(Option.Some(5).map((n) => n * 2));
 ```
 
 ## Who can contribute?

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,6 @@
 export {
   assertEquals,
   assertExists,
+  assertInstanceOf,
+  assertThrows,
 } from "https://deno.land/std@0.201.0/assert/mod.ts";

--- a/traits/into_iterator.ts
+++ b/traits/into_iterator.ts
@@ -2,18 +2,15 @@ import type { Iterator } from "./iterator.ts";
 
 export const IntoIteratorSymbol = Symbol("IntoIterator");
 
-export type IntoIteratorItem<I extends IntoIterator<unknown>> = I extends
-  IntoIterator<infer T> ? T : never;
+export interface IntoIteratorMethods<T> {
+  intoIter(): Iterator<T>;
+}
 export interface IntoIterator<T> {
-  [IntoIteratorSymbol]: {
-    intoIter(): Iterator<T>;
-  };
+  [IntoIteratorSymbol](): IntoIteratorMethods<T>;
 }
 
 export namespace IntoIterator {
-  export function intoIter<T extends IntoIterator<any>>(
-    obj: T,
-  ): Iterator<IntoIteratorItem<T>> {
-    return obj[IntoIteratorSymbol].intoIter();
+  export function intoIter<T>(obj: IntoIterator<T>): Iterator<T> {
+    return obj[IntoIteratorSymbol]().intoIter();
   }
 }

--- a/types/error.ts
+++ b/types/error.ts
@@ -1,0 +1,6 @@
+export class UnwrapError extends Error {
+  constructor() {
+    super();
+    this.name = "UnwrapError";
+  }
+}

--- a/types/mod.ts
+++ b/types/mod.ts
@@ -2,3 +2,4 @@ export * from "./const_iterator.ts";
 export * from "./map.ts";
 export * from "./option.ts";
 export * from "./result.ts";
+export * from "./error.ts";

--- a/types/result.test.ts
+++ b/types/result.test.ts
@@ -1,108 +1,97 @@
-import { assertEquals, assertExists } from "../deps.ts";
-import { Result } from "./result.ts";
-import { Option } from "./option.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertInstanceOf,
+  assertThrows,
+} from "../deps.ts";
+import { Err, Ok, Result } from "./result.ts";
+import { None, Some } from "./option.ts";
 import { IntoIteratorSymbol } from "../traits/into_iterator.ts";
 import { IteratorSymbol } from "../traits/iterator.ts";
+import { UnwrapError } from "./error.ts";
 
 Deno.test("Result<T, E>", async (t) => {
-  await t.step("isResult", async (t) => {
-    await t.step(
-      "Result.Ok => true",
-      () => assertEquals(Result.isResult(Result.Ok("Hello")), true),
-    );
+  await t.step(
+    "Ok",
+    () => assertInstanceOf(Result.Ok("Hello"), Ok<string, unknown>),
+  );
 
-    await t.step(
-      "Result.Err => true",
-      () => assertEquals(Result.isResult(Result.Err("Error")), true),
-    );
-
-    await t.step(
-      "string => false",
-      () => assertEquals(Result.isResult("Result"), false),
-    );
-
-    await t.step(
-      "number => false",
-      () => assertEquals(Result.isResult(5), false),
-    );
-
-    await t.step(
-      "boolean => false",
-      () => assertEquals(Result.isResult(true), false),
-    );
-
-    await t.step(
-      "Result<T, E>[] => false",
-      () => assertEquals(Result.isResult([Result.Ok(5)]), false),
-    );
-
-    await t.step(
-      "string[] => false",
-      () => assertEquals(Result.isResult(["Hello"]), false),
-    );
-
-    await t.step("{} => false", () => assertEquals(Result.isResult({}), false));
-
-    await t.step(
-      "null => false",
-      () => assertEquals(Result.isResult(null), false),
-    );
-
-    await t.step(
-      "undefined => false",
-      () => assertEquals(Result.isResult(undefined), false),
-    );
-  });
+  await t.step(
+    "Err",
+    () => assertInstanceOf(Result.Err("Fail"), Err<unknown, string>),
+  );
 
   await t.step("isOk", async (t) => {
     await t.step(
       "Result.Ok => true",
-      () => assertEquals(Result.isOk(Result.Ok("Hello")), true),
+      () => assertEquals(Result.Ok("Hello").isOk(), true),
     );
 
     await t.step(
       "Result.Err => false",
-      () => assertEquals(Result.isOk(Result.Err("Error")), false),
+      () => assertEquals(Result.Err("Error").isOk(), false),
     );
   });
 
   await t.step("isErr", async (t) => {
     await t.step(
       "Result.Ok => false",
-      () => assertEquals(Result.isErr(Result.Ok("Hello")), false),
+      () => assertEquals(Result.Ok("Hello").isErr(), false),
     );
 
     await t.step(
       "Result.Err => true",
-      () => assertEquals(Result.isErr(Result.Err("Error")), true),
+      () => assertEquals(Result.Err("Error").isErr(), true),
     );
+  });
+
+  await t.step("unwrap", async (t) => {
+    await t.step("Ok(data) => data", () => {
+      const data = "Hello";
+
+      assertEquals(Result.Ok(data).unwrap(), data);
+    });
+
+    await t.step("Err(err) => throws UnwrapError", () => {
+      assertThrows(
+        () => Result.Err("Fail").unwrap(),
+        UnwrapError,
+      );
+    });
+  });
+
+  await t.step("unwrapErr", async (t) => {
+    await t.step("Ok(data) => throws UnwrapError", () => {
+      assertThrows(
+        () => Result.Ok("Hello").unwrapErr(),
+        UnwrapError,
+      );
+    });
+
+    await t.step("Err(err) => err", () => {
+      const error = "Fail";
+
+      assertEquals(Result.Err(error).unwrapErr(), error);
+    });
   });
 
   await t.step("map", async (t) => {
     await t.step("Result.Ok => Result.Ok", () => {
       const innerValue = "Hello";
       const func = (s: string) => s.length;
-      const result = Result.map(Result.Ok(innerValue), func);
+      const result = Result.Ok(innerValue).map(func);
 
-      assertEquals(Result.isResult(result), true);
-
-      const isOk = Result.isOk(result);
-
-      assertEquals(isOk, true);
-      assertEquals(isOk && result.data, func(innerValue));
+      assertInstanceOf(result, Ok<number, unknown>);
+      assertEquals(result.unwrap(), func(innerValue));
     });
 
     await t.step("Result.Err => Result.Err", () => {
       const error = "Error";
       const func = (s: string) => s.length;
-      const result = Result.map(Result.Err<string, string>(error), func);
+      const result = Result.Err<string, string>(error).map(func);
 
-      assertEquals(Result.isResult(result), true);
-
-      const isErr = Result.isErr(result);
-
-      assertEquals(isErr, true);
-      assertEquals(isErr && result.error, error);
+      assertInstanceOf(result, Err<number, string>);
+      assertEquals(result.unwrapErr(), error);
     });
   });
 
@@ -110,38 +99,31 @@ Deno.test("Result<T, E>", async (t) => {
     await t.step("intoIter", async (t) => {
       await t.step("Result.Ok(data) => Iterator over [data]", () => {
         const result = Result.Ok(5);
-        const iter = result[IntoIteratorSymbol].intoIter();
+        const iter = result[IntoIteratorSymbol]().intoIter();
 
         assertExists(iter[IteratorSymbol]);
 
-        const firstItem = iter[IteratorSymbol].next();
+        const iterTraitMethods = iter[IteratorSymbol]();
+
+        const firstItem = iterTraitMethods.next();
 
         // rest is duplicate from option.test.ts
         // maybe check later if deduplication is needed
-        assertEquals(Option.isOption(firstItem), true);
+        assertInstanceOf(firstItem, Some<number>);
+        assertEquals(firstItem.unwrap(), 5);
 
-        const firstItemIsSome = Option.isSome(firstItem);
+        const secondItem = iterTraitMethods.next();
 
-        assertEquals(firstItemIsSome, true);
-        assertEquals(firstItemIsSome && firstItem.value, 5);
-
-        const secondItem = iter[IteratorSymbol].next();
-
-        assertEquals(Option.isOption(secondItem), true);
-        assertEquals(Option.isNone(secondItem), true);
+        assertInstanceOf(secondItem, None<number>);
       });
 
       // check that it returns an iterator that will yield no items
       await t.step("Result.Err => Iterator over []", () => {
         const result = Result.Err("Error");
-        const iter = result[IntoIteratorSymbol].intoIter();
+        const iter = result[IntoIteratorSymbol]().intoIter();
 
         assertExists(iter[IteratorSymbol]);
-
-        const item = iter[IteratorSymbol].next();
-
-        assertEquals(Option.isOption(item), true);
-        assertEquals(Option.isNone(item), true);
+        assertInstanceOf(iter[IteratorSymbol]().next(), None);
       });
     });
   });

--- a/types/result.ts
+++ b/types/result.ts
@@ -1,12 +1,11 @@
-import { hasProperty, isObject } from "./utils.ts";
 import { ConstIterator } from "./const_iterator.ts";
 import {
   type IntoIterator,
+  IntoIteratorMethods,
   IntoIteratorSymbol,
 } from "../traits/into_iterator.ts";
 import type { Iterator } from "../traits/iterator.ts";
-
-export const ResultSymbol = Symbol("Result");
+import { UnwrapError } from "./error.ts";
 
 /**
  * `Result<T, E>` is the type used for returning and propagating errors. It is
@@ -15,83 +14,38 @@ export const ResultSymbol = Symbol("Result");
  *
  * Functions return `Result` whenever errors are expected and recoverable.
  */
-export type Result<T, E> =
-  & { type: symbol }
-  & (
-    | { variant: "Ok"; data: T }
-    | { variant: "Err"; error: E }
-  )
-  & IntoIterator<T>;
+export abstract class Result<T, E> implements IntoIterator<T> {
+  static Ok<T, E>(data: T) {
+    return new Ok<T, E>(data);
+  }
 
-export namespace Result {
-  /**
-   * Create an `Ok` variant of `Result`
-   */
-  export function Ok<T, E>(data: T): Result<T, E> {
-    return {
-      type: ResultSymbol,
-      variant: "Ok",
-      data,
-      [IntoIteratorSymbol]: {
-        intoIter(): Iterator<T> {
-          return ConstIterator.create([data]);
-        },
-      },
-    };
+  static Err<T, E>(error: E) {
+    return new Err<T, E>(error);
+  }
+
+  isOk(): this is Ok<T, E> {
+    return this instanceof Ok;
+  }
+
+  isErr(): this is Err<T, E> {
+    return this instanceof Err;
   }
 
   /**
-   * Create an `Err` variant of `Result`
+   * @returns The contained data if `this` is `Ok`, otherwise throw
+   * `UnwrapError`
    */
-  export function Err<T, E>(error: E): Result<T, E> {
-    return {
-      type: ResultSymbol,
-      variant: "Err",
-      error,
-      [IntoIteratorSymbol]: {
-        intoIter(): Iterator<T> {
-          return ConstIterator.create([]);
-        },
-      },
-    };
-  }
+  abstract unwrap(): T;
 
   /**
-   * @returns Whether `maybeResult` is a `Result`
+   * @returns The contained error if `this` is `Err`, otherwise throw
+   * `UnwrapError`
    */
-  export function isResult(
-    maybeResult: unknown,
-  ): maybeResult is Result<unknown, unknown> {
-    return (
-      isObject(maybeResult) &&
-      hasProperty(maybeResult, "type") &&
-      maybeResult.type === ResultSymbol
-    );
-  }
+  abstract unwrapErr(): E;
 
   /**
-   * @returns Whether `result` is an `Ok` variant of `Result`
-   * @see Result.Ok
-   */
-  export function isOk<T, E>(
-    result: Result<T, E>,
-  ): result is Result<T, E> & { variant: "Ok" } {
-    return result.variant === "Ok";
-  }
-
-  /**
-   * @returns Whether `result` is an `Err` variant of `Result`
-   * @see Result.Err
-   */
-  export function isErr<T, E>(
-    result: Result<T, E>,
-  ): result is Result<T, E> & { variant: "Err" } {
-    return result.variant === "Err";
-  }
-
-  /**
-   * Map a `Result` on one type of successful data to a Result on another
-   * by applying a function to the inner data if it's an `Ok` variant.
+   * Map `this` to a Result on another successful type by applying a function
+   * to the inner data if it's an `Ok` variant.
    * @param result `Result` to map from
    * @param fn Mapping `function`
    * @returns Mapped `Result`
@@ -104,16 +58,69 @@ export namespace Result {
    * @example
    * // Result<string, boolean>
    * // Result.Err(false)
-   * Result.map(Result.Err<number, string>(false), n => n.toFixed(2));
+   * Result.map(Result.Err<number, boolean>(false), n => n.toFixed(2));
    */
-  export function map<T, E, U>(
-    result: Result<T, E>,
-    fn: (arg: T) => U,
-  ): Result<U, E> {
-    if (Result.isOk(result)) {
-      return Result.Ok(fn(result.data));
-    }
+  abstract map<U>(fn: (arg: T) => U): Result<U, E>;
 
-    return Result.Err(result.error);
+  abstract [IntoIteratorSymbol](): IntoIteratorMethods<T>;
+}
+
+export class Ok<T, E> extends Result<T, E> {
+  #data: T;
+
+  constructor(data: T) {
+    super();
+    this.#data = data;
+  }
+
+  unwrap(): T {
+    return this.#data;
+  }
+
+  unwrapErr(): E {
+    throw new UnwrapError();
+  }
+
+  map<U>(fn: (arg: T) => U): Result<U, E> {
+    return Result.Ok(fn(this.#data));
+  }
+
+  [IntoIteratorSymbol](): IntoIteratorMethods<T> {
+    const data = this.#data;
+
+    return {
+      intoIter(): Iterator<T> {
+        return ConstIterator.create([data]);
+      },
+    };
+  }
+}
+
+export class Err<T, E> extends Result<T, E> {
+  #error: E;
+
+  constructor(error: E) {
+    super();
+    this.#error = error;
+  }
+
+  unwrap(): T {
+    throw new UnwrapError();
+  }
+
+  unwrapErr(): E {
+    return this.#error;
+  }
+
+  map<U>(_fn: (arg: T) => U): Result<U, E> {
+    return Result.Err(this.#error);
+  }
+
+  [IntoIteratorSymbol](): IntoIteratorMethods<T> {
+    return {
+      intoIter(): Iterator<T> {
+        return ConstIterator.create<T>([]);
+      },
+    };
   }
 }

--- a/utils/tuple.ts
+++ b/utils/tuple.ts
@@ -66,3 +66,18 @@ type _Reverse<Tuple extends any[], Reversed extends any[] = []> =
  * Reverse<[1, 2, 3]>
  */
 export type Reverse<Tuple extends any[]> = _Reverse<Tuple>;
+
+/**
+ * Assert that T is a 2-Tuple and infer its type
+ *
+ * @example
+ * // ["Hello", 5]
+ * TwoTuple<["Hello", 5]>
+ *
+ * @example
+ * // never
+ * TwoTuple<"World">
+ */
+export type TwoTuple<T> = T extends [infer First, infer Second]
+  ? [First, Second]
+  : never;


### PR DESCRIPTION
[6838a0b](https://github.com/pgiammel/hematite/commit/6838a0b010afe964812e08171a3129bd0357ff31)
- Update Option to an abstract class
- Add Some and None, subclasses of Option
- Add Option.unwrap and Option.unwrapOr
- Rename Option methods to camel case
- Update Result to an abstract class
- Add Ok and Err, subclasses of Result
- Add Result.unwrap and Result.unwrapErr
- Update Map to a class
- Update ConstIterator to a class
- Update "trait" system to use functions
- Simplify generic bounds (e.g. Map)

[1f9c339](https://github.com/pgiammel/hematite/commit/1f9c3391c98889bc657672c5b5ca27d2a2b7caf8)
- Update README.md code examples